### PR TITLE
Add static site skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# automatic-spork
+# Dan's Static Site
+
+This repo contains a lightweight static website structured for GitHub Pages.
+All pages are plain HTML with Tailwind CSS from a CDN.
+
+## Adding Pages
+1. Create your HTML file inside `blog/`, `portfolio/`, `garden/`, or `hub/`.
+2. Add an entry to `search.json` with title, url, tags, and excerpt.
+3. Push changes to GitHub; Pages will serve them automatically.
+
+## Development Tips
+- Use `dark-mode.js` for theme toggling via the button in the header.
+- `search.js` is a minimal ES6 module for fetching `search.json`.
+
+## Deploying
+Simply push to the `main` branch (or enable GitHub Pages in settings).

--- a/blog/2025-05-psychiatry-sleep.html
+++ b/blog/2025-05-psychiatry-sleep.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<!-- Demo blog post about sleep and psychiatry -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Psychiatry and Sleep</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script type="module" src="/js/dark-mode.js"></script>
+</head>
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+  <nav aria-label="Main" class="p-4"><a href="/" class="underline">Home</a></nav>
+  <article class="prose dark:prose-dark mx-auto p-4">
+    <h1>Psychiatry and the Importance of Sleep</h1>
+    <p>Lorem for now: exploring how sleep impacts mental health.</p>
+  </article>
+</body>
+</html>

--- a/garden/welcome.html
+++ b/garden/welcome.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<!-- Intro page for Thought Garden with placeholder notes -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Thought Garden</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script type="module" src="/js/dark-mode.js"></script>
+</head>
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+  <nav aria-label="Main" class="p-4"><a href="/" class="underline">Home</a></nav>
+  <section class="prose dark:prose-dark mx-auto p-4">
+    <h1>Welcome to the Thought Garden</h1>
+    <p>Lorem for now: short notes, daily logs, and study snippets.</p>
+  </section>
+</body>
+</html>

--- a/hub/index.html
+++ b/hub/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!-- Hub page with links to Dan's external profiles -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dan's Hub</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script type="module" src="/js/dark-mode.js"></script>
+</head>
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+  <nav aria-label="Main" class="p-4"><a href="/" class="underline">Home</a></nav>
+  <section class="max-w-prose mx-auto p-4 space-y-2">
+    <h1 class="text-3xl font-semibold mb-4">Outbound Links</h1>
+    <ul class="list-disc pl-5">
+      <li><a href="#" class="text-blue-600 underline">Amazon Wishlist</a></li>
+      <li><a href="#" class="text-blue-600 underline">GitHub</a></li>
+      <li><a href="#" class="text-blue-600 underline">Chess.com</a></li>
+      <li><a href="#" class="text-blue-600 underline">Social Profiles</a></li>
+    </ul>
+  </section>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<!-- Root landing page with hero and links to site sections -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dan's Space</title>
+  <!-- Tailwind via CDN -->
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script type="module" src="/js/dark-mode.js"></script>
+</head>
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+  <header class="text-center py-12">
+    <h1 class="text-4xl font-bold mb-4">Welcome to Dan's Space</h1>
+    <p class="max-w-prose mx-auto">A hub for psychiatry, strength training, theology, coding, and poetry.</p>
+    <button id="themeToggle" class="mt-4 px-4 py-2 border rounded">Toggle Dark Mode</button>
+  </header>
+  <main class="max-w-4xl mx-auto grid gap-6 sm:grid-cols-2 p-4">
+    <a href="/blog/" class="block rounded-2xl p-6 shadow-md bg-white dark:bg-gray-800 hover:shadow-lg">
+      <h2 class="text-2xl font-semibold mb-2">Blog</h2>
+      <p>Evidence-based articles.</p>
+    </a>
+    <a href="/portfolio/" class="block rounded-2xl p-6 shadow-md bg-white dark:bg-gray-800 hover:shadow-lg">
+      <h2 class="text-2xl font-semibold mb-2">Portfolio</h2>
+      <p>Case reports, slides, code, and poems.</p>
+    </a>
+    <a href="/garden/" class="block rounded-2xl p-6 shadow-md bg-white dark:bg-gray-800 hover:shadow-lg">
+      <h2 class="text-2xl font-semibold mb-2">Thought Garden</h2>
+      <p>Loose notes, Bible-reading CSVs, and workout logs.</p>
+    </a>
+    <a href="/hub/" class="block rounded-2xl p-6 shadow-md bg-white dark:bg-gray-800 hover:shadow-lg">
+      <h2 class="text-2xl font-semibold mb-2">Hub</h2>
+      <p>Outbound links and social profiles.</p>
+    </a>
+  </main>
+</body>
+</html>

--- a/js/dark-mode.js
+++ b/js/dark-mode.js
@@ -1,0 +1,7 @@
+// Toggle dark mode by switching the 'dark' class on <html>
+const btn = document.getElementById('themeToggle');
+if (btn) {
+  btn.addEventListener('click', () => {
+    document.documentElement.classList.toggle('dark');
+  });
+}

--- a/js/search.js
+++ b/js/search.js
@@ -1,0 +1,9 @@
+// Simple client-side search fetching prebuilt search.json
+export async function runSearch(query) {
+  const res = await fetch('/search.json');
+  const data = await res.json();
+  return data.filter(item =>
+    item.title.toLowerCase().includes(query.toLowerCase()) ||
+    item.tags.some(t => t.includes(query.toLowerCase()))
+  );
+}

--- a/portfolio/sample-case.html
+++ b/portfolio/sample-case.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<!-- Example portfolio page with placeholder content -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sample Case Report</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script type="module" src="/js/dark-mode.js"></script>
+</head>
+<body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+  <nav aria-label="Main" class="p-4"><a href="/" class="underline">Home</a></nav>
+  <main class="prose dark:prose-dark mx-auto p-4">
+    <h1>Sample Case Report</h1>
+    <p>Lorem for now: a brief description of a clinical case.</p>
+  </main>
+</body>
+</html>

--- a/search.json
+++ b/search.json
@@ -1,0 +1,14 @@
+[
+  {
+    "title": "Psychiatry and Sleep",
+    "url": "/blog/2025-05-psychiatry-sleep.html",
+    "tags": ["psychiatry", "sleep"],
+    "excerpt": "Lorem for now: exploring how sleep impacts mental health."
+  },
+  {
+    "title": "Sample Case Report",
+    "url": "/portfolio/sample-case.html",
+    "tags": ["case", "report"],
+    "excerpt": "Lorem for now: a brief description of a clinical case."
+  }
+]


### PR DESCRIPTION
## Summary
- build out index with dark mode toggle and Tailwind CDN link
- add demo Blog, Portfolio, Thought Garden, and Hub pages
- include minimal JS for dark mode and search
- provide example search.json and contribution README

## Testing
- `git status --short`