### PR TITLE
Refactor site to use header/footer partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ All pages are plain HTML with Tailwind CSS from a CDN.
 
 ## Development Tips
  - `dark-mode.js` toggles the theme and now stores your preference in `localStorage`.
- - `search.js` is a minimal ES6 module for fetching `search.json`.
+- `search.js` is a minimal ES6 module for fetching `search.json`.
+- Run `node build.js` to inject the shared header and footer into all pages before deploying.
 
 ## Deploying
 Simply push to the `main` branch (or enable GitHub Pages in settings).

--- a/blog/2025-05-psychiatry-sleep.html
+++ b/blog/2025-05-psychiatry-sleep.html
@@ -13,13 +13,11 @@
   <script type="module" src="/js/dark-mode.js"></script>
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-  <nav aria-label="Main" class="p-4 flex justify-between">
-    <a href="/" class="underline">Home</a>
-    <button id="themeToggle" aria-label="Toggle dark mode" class="border rounded px-2 py-1">Toggle Dark Mode</button>
-  </nav>
+  {{header}}
   <article class="prose dark:prose-dark mx-auto p-4">
     <h1>Psychiatry and the Importance of Sleep</h1>
     <p>Quality sleep is vital for emotional regulation and cognitive performance. This post surveys recent findings linking rest with psychiatric wellbeing.</p>
   </article>
+  {{footer}}
 </body>
 </html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -12,15 +12,13 @@
   <script type="module" src="/js/dark-mode.js"></script>
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-  <nav aria-label="Main" class="p-4 flex justify-between">
-    <a href="/" class="underline">Home</a>
-    <button id="themeToggle" aria-label="Toggle dark mode" class="border rounded px-2 py-1">Toggle Dark Mode</button>
-  </nav>
+  {{header}}
   <main class="max-w-prose mx-auto p-4 space-y-4">
     <h1 class="text-3xl font-semibold">Blog</h1>
     <ul class="list-disc pl-5">
       <li><a href="/blog/2025-05-psychiatry-sleep.html" class="text-blue-600 underline">Psychiatry and Sleep</a></li>
     </ul>
   </main>
+  {{footer}}
 </body>
 </html>

--- a/build.js
+++ b/build.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+
+const header = fs.readFileSync(path.join(__dirname, 'partials', 'header.html'), 'utf8');
+const footer = fs.readFileSync(path.join(__dirname, 'partials', 'footer.html'), 'utf8');
+
+const dirs = ['.', 'blog', 'garden', 'hub', 'portfolio'];
+
+for (const dir of dirs) {
+  for (const file of fs.readdirSync(dir)) {
+    if (!file.endsWith('.html')) continue;
+    const filePath = path.join(dir, file);
+    let html = fs.readFileSync(filePath, 'utf8');
+    html = html.replace(/\{\{header\}\}/g, header).replace(/\{\{footer\}\}/g, footer);
+    fs.writeFileSync(filePath, html);
+  }
+}

--- a/garden/index.html
+++ b/garden/index.html
@@ -12,15 +12,13 @@
   <script type="module" src="/js/dark-mode.js"></script>
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-  <nav aria-label="Main" class="p-4 flex justify-between">
-    <a href="/" class="underline">Home</a>
-    <button id="themeToggle" aria-label="Toggle dark mode" class="border rounded px-2 py-1">Toggle Dark Mode</button>
-  </nav>
+  {{header}}
   <main class="max-w-prose mx-auto p-4 space-y-4">
     <h1 class="text-3xl font-semibold">Thought Garden</h1>
     <ul class="list-disc pl-5">
       <li><a href="/garden/welcome.html" class="text-blue-600 underline">Welcome</a></li>
     </ul>
   </main>
+  {{footer}}
 </body>
 </html>

--- a/garden/welcome.html
+++ b/garden/welcome.html
@@ -13,13 +13,11 @@
   <script type="module" src="/js/dark-mode.js"></script>
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-  <nav aria-label="Main" class="p-4 flex justify-between">
-    <a href="/" class="underline">Home</a>
-    <button id="themeToggle" aria-label="Toggle dark mode" class="border rounded px-2 py-1">Toggle Dark Mode</button>
-  </nav>
+  {{header}}
   <section class="prose dark:prose-dark mx-auto p-4">
     <h1>Welcome to the Thought Garden</h1>
     <p>Here you'll find brief musings, daily logs, and study notes as they evolve.</p>
   </section>
+  {{footer}}
 </body>
 </html>

--- a/hub/index.html
+++ b/hub/index.html
@@ -13,10 +13,7 @@
   <script type="module" src="/js/dark-mode.js"></script>
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-  <nav aria-label="Main" class="p-4 flex justify-between">
-    <a href="/" class="underline">Home</a>
-    <button id="themeToggle" aria-label="Toggle dark mode" class="border rounded px-2 py-1">Toggle Dark Mode</button>
-  </nav>
+  {{header}}
   <section class="max-w-prose mx-auto p-4 space-y-2">
     <h1 class="text-3xl font-semibold mb-4">Outbound Links</h1>
     <ul class="list-disc pl-5">
@@ -26,5 +23,6 @@
       <li><a href="#" class="text-blue-600 underline">Social Profiles</a></li>
     </ul>
   </section>
+  {{footer}}
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
   <script type="module" src="/js/dark-mode.js"></script>
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+  {{header}}
   <header class="text-center py-12">
     <h1 class="text-4xl font-bold mb-4">Welcome to Dan's Space</h1>
     <p class="max-w-prose mx-auto">A hub for psychiatry, strength training, theology, coding, and poetry.</p>
-    <button id="themeToggle" aria-label="Toggle dark mode" class="mt-4 px-4 py-2 border rounded">Toggle Dark Mode</button>
   </header>
   <main class="max-w-4xl mx-auto grid gap-6 sm:grid-cols-2 p-4">
     <a href="/blog/" class="block rounded-2xl p-6 shadow-md bg-white dark:bg-gray-800 hover:shadow-lg">
@@ -37,5 +37,6 @@
       <p>Outbound links and social profiles.</p>
     </a>
   </main>
+  {{footer}}
 </body>
 </html>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,9 @@
+<footer class="text-center p-4 border-t mt-8">
+  <nav class="space-x-4">
+    <a href="/blog/" class="underline">Blog</a>
+    <a href="/portfolio/" class="underline">Portfolio</a>
+    <a href="/garden/" class="underline">Garden</a>
+    <a href="/hub/" class="underline">Hub</a>
+  </nav>
+  <p class="mt-2 text-sm">&copy; 2024 Dan</p>
+</footer>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,4 @@
+<nav aria-label="Main" class="p-4 flex justify-between">
+  <a href="/" class="underline">Home</a>
+  <button id="themeToggle" aria-label="Toggle dark mode" class="border rounded px-2 py-1">Toggle Dark Mode</button>
+</nav>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -12,15 +12,13 @@
   <script type="module" src="/js/dark-mode.js"></script>
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-  <nav aria-label="Main" class="p-4 flex justify-between">
-    <a href="/" class="underline">Home</a>
-    <button id="themeToggle" aria-label="Toggle dark mode" class="border rounded px-2 py-1">Toggle Dark Mode</button>
-  </nav>
+  {{header}}
   <main class="max-w-prose mx-auto p-4 space-y-4">
     <h1 class="text-3xl font-semibold">Portfolio</h1>
     <ul class="list-disc pl-5">
       <li><a href="/portfolio/sample-case.html" class="text-blue-600 underline">Sample Case Report</a></li>
     </ul>
   </main>
+  {{footer}}
 </body>
 </html>

--- a/portfolio/sample-case.html
+++ b/portfolio/sample-case.html
@@ -13,13 +13,11 @@
   <script type="module" src="/js/dark-mode.js"></script>
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-  <nav aria-label="Main" class="p-4 flex justify-between">
-    <a href="/" class="underline">Home</a>
-    <button id="themeToggle" aria-label="Toggle dark mode" class="border rounded px-2 py-1">Toggle Dark Mode</button>
-  </nav>
+  {{header}}
   <main class="prose dark:prose-dark mx-auto p-4">
     <h1>Sample Case Report</h1>
     <p>An overview of a patient scenario illustrating assessment, treatment plan, and outcome.</p>
   </main>
+  {{footer}}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace inline nav on pages with `{{header}}` placeholder
- add matching `{{footer}}` placeholder and partial file
- introduce `build.js` to inject partials before deployment
- document build step in README

## Testing
- `node -v`
- `node build.js` (verified header/footer were injected, then reverted)
- `git status --short`