### PR TITLE
Initialize pages with dark theme

### DIFF
--- a/js/dark-mode.js
+++ b/js/dark-mode.js
@@ -3,7 +3,8 @@ const btn = document.getElementById('themeToggle');
 const root = document.documentElement;
 const stored = localStorage.getItem('theme');
 
-if (stored === 'dark') {
+// Default to dark when no preference is stored
+if (stored === 'dark' || stored === null) {
   root.classList.add('dark');
 }
 


### PR DESCRIPTION
## Summary
- default to dark mode when no theme is stored in `localStorage`

## Testing
- `grep -n "dark-mode.js" -n $(find . -name '*.html') | head`
